### PR TITLE
feat: 画像をキャッシュさせるサーバの実装

### DIFF
--- a/server.js
+++ b/server.js
@@ -48,3 +48,30 @@ appC.post("/", (req, res) => {
 });
 
 appC.listen(3002);
+
+const imageServerA = express();
+
+imageServerA.use("/", (req, res, next) => {
+  res.header("Cache-Control", "max-age=60");
+  next();
+});
+imageServerA.use("/", express.static("staticsB"));
+
+imageServerA.listen(3003);
+
+const imageServerB = express();
+
+imageServerB.use("/", (req, res, next) => {
+  res.header("Cache-Control", "no-cache");
+  next();
+});
+
+imageServerB.use("/", express.static("staticsB"));
+
+imageServerB.listen(3004);
+
+const appD = express();
+
+appD.use("/", express.static("staticsD"));
+
+appD.listen(3005);

--- a/staticsD/index.html
+++ b/staticsD/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>title</title>
+  </head>
+  <body>
+    <img src="http://localhost:3003/sample.jpg" />
+    <img src="http://localhost:3004/sample.jpg" />
+  </body>
+</html>


### PR DESCRIPTION
### 実装内容

- imageServerAでは画像をホストして、レスポンスのCache-Controlにmax-age=60を指定
- imageServerBでは画像をホストして、レスポンスのCache-Controlにno-cacheを指定